### PR TITLE
supress warning when no params

### DIFF
--- a/lib/Test/LWP/Recorder.pm
+++ b/lib/Test/LWP/Recorder.pm
@@ -41,6 +41,7 @@ sub _filter_all_params {
     ## no critic (BuiltinFunctions::ProhibitStringySplit)
     my %query = map { ( split q{=} )[ 0, 1 ] } split q{\&}, $param_string;
     ## use critic;
+    return '' unless %query;
     return reduce { $a . $self->_filter_param( $b, $query{$b} ) }
     sort keys %query;
 }


### PR DESCRIPTION
This patch removes this warning:

t/mirror_recorded.t ........ 1/7 Use of uninitialized value in concatenation (.) or string at /home/ollisg/dev/Test-LWP-Recorder/lib/Test/LWP/Recorder.pm line 58.

without (I believe) altering the behavior.
