### PR TITLE
Changed PWP::Encoding to PWP::SingleEncoding

### DIFF
--- a/weaver.ini
+++ b/weaver.ini
@@ -1,7 +1,7 @@
 ; borrowed from APOCAL's Pod-Weaver-PluginBundle-Apocalyptic
 [@CorePrep]                     ; setup the pod stuff
-[-Encoding]                      ; add the =encoding command to your POD via Pod::Weaver::Plugin::Encoding
-encoding = utf-8
+[-SingleEncoding]               ; add the =encoding command to your POD via Pod::Weaver::Plugin::SingleEncoding
+encoding = UTF-8
 [Region / Pod::Coverage]        ; move any Pod::Coverage markers to the top ( =for Pod::Coverage foo bar )
 [-StopWords]
 [Name]                          ; automatically generate the NAME section


### PR DESCRIPTION
Hi,

`Pod::Weaver` has `SingleEncoding` plugin now (starting from 4.000), which makes `Pod::Weaver::Plugin::Encoding` an extra dependency that could be thrown away.

See [Rik's post](http://rjbs.manxome.org/rubric/entry/2021) and also check out my quest for details/comments:

> http://questhub.io/realm/perl/quest/5277f3cc9f567ad56f0000e7

Cheers,
Sergey
